### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-moss-092380610.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-moss-092380610.yml
@@ -1,5 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/adroitstart/adroitstartweb/security/code-scanning/2](https://github.com/adroitstart/adroitstartweb/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow:
- The `build_pr` job requires read access to the repository contents to check out the code and build/test it.
- The `build_and_deploy_job` requires read access to the repository contents and write access to pull requests for GitHub integrations (e.g., PR comments).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, we will add it at the root level for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
